### PR TITLE
Add info about boost support

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ Besides mere compilation, most online compilers also execute the compiled progra
 | Name | Number Compilers | C++ version | boost version | Execution | Distinguishing features | Other Languages |
 |------|:----------------:|:-----------:|:-------------:|:---------:|-------------------------|:---------------:|
 | [Wandbox](http://melpon.org/wandbox) | 35 | C++17 | 1.64 | ✔️ | multiple files | ✔️ |
-| [Compiler Explorer (Godbolt)](http://godbolt.org) | 60+ | C++17 |  |  | compile to assembly as you type, on multiple compilers | ✔️ |
+| [Compiler Explorer (Godbolt)](http://godbolt.org) | 60+ | C++17 | 1.64 |  | compile to assembly as you type, on multiple compilers | ✔️ |
 | [Coliru](http://coliru.stacked-crooked.com) | 2 | C++17 | 1.63 (header only) | ✔️ | GCC & Clang, freely editable shell command line |  |
 | [Rextester](http://rextester.com/) | 3 | C++14 | 1.58 (header only) | ✔️ | GCC, Clang, MSVC, collaborative live editing features | ✔️ |
 | [Ideone](https://ideone.com/) | 1 | C++14 | 1.62 (header only) | ✔️ | GCC | ✔️ |
@@ -65,6 +65,7 @@ The snapshot versions of GCC and Clang that are provided make it possible to pla
 ![Compiler flags: free text](https://img.shields.io/badge/flags-free%20text-brightgreen.svg)
 ![](https://img.shields.io/badge/assembly-yes-brightgreen.svg)
 ![](https://img.shields.io/badge/execution-no-red.svg)    
+![](https://img.shields.io/badge/libraries-Boost-ff69b4.svg)
 ![](https://img.shields.io/badge/interactive-compilation-ff69b4.svg)
 ![](https://img.shields.io/badge/diff%20assembler-yes-ff69b4.svg)
 ![](https://img.shields.io/badge/include-github-ff69b4.svg)

--- a/index.md
+++ b/index.md
@@ -66,7 +66,6 @@ The snapshot versions of GCC and Clang that are provided make it possible to pla
 ![](https://img.shields.io/badge/assembly-yes-brightgreen.svg)
 ![](https://img.shields.io/badge/execution-no-red.svg)    
 ![](https://img.shields.io/badge/interactive-compilation-ff69b4.svg)
-![](https://img.shields.io/badge/libraries-Boost-ff69b4.svg)
 ![](https://img.shields.io/badge/diff%20assembler-yes-ff69b4.svg)
 ![](https://img.shields.io/badge/include-github-ff69b4.svg)
 ![](https://img.shields.io/badge/sharing-link%20|%20embed-ff69b4.svg)
@@ -84,6 +83,7 @@ Currently, the compiled code can **not** be executed, but there is an [open GitH
 ![Compiler flags: free text](https://img.shields.io/badge/flags-free%20text-brightgreen.svg)
 ![Runtime parameters: yes](https://img.shields.io/badge/runtime%20parameters-yes-brightgreen.svg)
 ![Stdin: yes](https://img.shields.io/badge/stdin-shell%2Bpipe-brightgreen.svg)  
+![](https://img.shields.io/badge/libraries-Boost-ff69b4.svg)
 ![](https://img.shields.io/badge/sharing-link-ff69b4.svg)
 
 [Coliru](http://coliru.stacked-crooked.com) provides an editor and a freely editable Linux shell command line, which makes it relatively powerful. For example, you can compare the outputs of both Clang and GCC by issuing the commands for compilation and execution for both compilers. Editing of multiple files at once is not supported, but since the code you share is saved in an archive you can use that to prepare multiple files (see the [FAQ](https://docs.google.com/document/d/18md3rLdgD9f5Wro3i7YYopJBFb_6MPCO8-0ihtxHoyM/edit) for an example). It is also possible to download e.g. a Gist via `curl` before the compilation.
@@ -99,6 +99,7 @@ Coliru provides a public API, so it can, for example, be integrated into website
 ![Compiler flags: free text](https://img.shields.io/badge/flags-free%20text-brightgreen.svg)
 ![Runtime parameters: no](https://img.shields.io/badge/runtime%20parameters-no-red.svg)
 ![Stdin: yes](https://img.shields.io/badge/stdin-yes-brightgreen.svg)    
+![](https://img.shields.io/badge/libraries-Boost-ff69b4.svg)
 ![](https://img.shields.io/badge/sharing-link-ff69b4.svg)
 ![](https://img.shields.io/badge/interactive-live_editing-ff69b4.svg)
 
@@ -112,6 +113,7 @@ Coliru provides a public API, so it can, for example, be integrated into website
 ![Compiler flags: free text](https://img.shields.io/badge/flags-predefined-red.svg)
 ![Runtime parameters: no](https://img.shields.io/badge/runtime%20parameters-no-red.svg)
 ![Stdin: yes](https://img.shields.io/badge/stdin-yes-brightgreen.svg)  
+![](https://img.shields.io/badge/libraries-Boost-ff69b4.svg)
 ![](https://img.shields.io/badge/sharing-link-ff69b4.svg)
 
 
@@ -136,6 +138,7 @@ Coliru provides a public API, so it can, for example, be integrated into website
 ![](https://img.shields.io/badge/flags-reduced%20set-yellowgreen.svg)
 ![](https://img.shields.io/badge/runtime%20parameters-no-red.svg)
 ![](https://img.shields.io/badge/stdin-static%20|%20interactive-brightgreen.svg)  
+![](https://img.shields.io/badge/libraries-Boost-ff69b4.svg)
 ![](https://img.shields.io/badge/sharing-link-ff69b4.svg)
 ![](https://img.shields.io/badge/interactive-stdin-ff69b4.svg)
 
@@ -189,6 +192,7 @@ An online IDE with multiple files. The whole web application seems to be sluggis
 ![](https://img.shields.io/badge/flags-predefined-red.svg)
 ![](https://img.shields.io/badge/runtime%20parameters-no-red.svg)
 ![](https://img.shields.io/badge/stdin-no-red.svg)  
+![](https://img.shields.io/badge/libraries-Boost-ff69b4.svg)
 ![](https://img.shields.io/badge/sharing-link-ff69b4.svg)
 
 [Codepad](http://codepad.org/) can be unintuitive - pasting new code at the URL of previously pasted code will return to the original code. The code will be compiled and executed as-is without any possibility to further parametrize it.

--- a/index.md
+++ b/index.md
@@ -12,20 +12,20 @@ Besides mere compilation, most online compilers also execute the compiled progra
 
 ## TL;DR 
 
-| Name | Number Compilers | C++ version | Execution | Distinguishing features | Other Languages |
-|------|:----------------:|:-----------:|:---------:|-------------------------|:---------------:|
-| [Wandbox](http://melpon.org/wandbox) | 35 | C++17 | ✔️ | multiple files | ✔️ |
-| [Compiler Explorer (Godbolt)](http://godbolt.org) | 60+ | C++17 |  | compile to assembly as you type, on multiple compilers | ✔️ |
-| [Coliru](http://coliru.stacked-crooked.com) | 2 | C++17 | ✔️ | GCC & Clang, freely editable shell command line |  |
-| [Rextester](http://rextester.com/) | 3 | C++14 | ✔️ | GCC, Clang, MSVC, collaborative live editing features | ✔️ |
-| [Ideone](https://ideone.com/) | 1 | C++14 | ✔️ | GCC | ✔️ |
-| [Visual C++ Compiler Online](http://webcompiler.cloudapp.net/) | 1 | C++14-17 | ✔️ | up-to-date MSVC 19/2017 |  |
-| [C++ Shell](http://cpp.sh/) | 1 | C++11-14 | ✔️ | GCC, interactive Stdin |  |
-| [repl.it](https://repl.it/languages/cpp11) | 1 | C++17 | ✔️ | GCC, interactive Stdin | ✔️ |
-| [Tutorialspoint CodingGround](https://www.tutorialspoint.com/compile_cpp11_online.php) | 1 | C++11 | ✔️ | multiple files like proper IDE, GCC <br/> but sluggish web app |  |
-| [Codepad](http://codepad.org/) | 1 | C++03 | ✔️ | GCC | ✔️ |
-| [TIO - Try It Online](https://tio.run/#cpp-gcc) | 1 | C++14 | ✔️ | Easy sharing, split source in header, source and footer | ✔️ |
-| [LoopPerfect C++ Fiddle](http://fiddle.jyt.io/) |  | |  | interactive C++ interpreter/terminal, but currently broken |  |
+| Name | Number Compilers | C++ version | boost version | Execution | Distinguishing features | Other Languages |
+|------|:----------------:|:-----------:|:-------------:|:---------:|-------------------------|:---------------:|
+| [Wandbox](http://melpon.org/wandbox) | 35 | C++17 | 1.64 | ✔️ | multiple files | ✔️ |
+| [Compiler Explorer (Godbolt)](http://godbolt.org) | 60+ | C++17 |  |  | compile to assembly as you type, on multiple compilers | ✔️ |
+| [Coliru](http://coliru.stacked-crooked.com) | 2 | C++17 | 1.63 (header only) | ✔️ | GCC & Clang, freely editable shell command line |  |
+| [Rextester](http://rextester.com/) | 3 | C++14 | 1.58 (header only) | ✔️ | GCC, Clang, MSVC, collaborative live editing features | ✔️ |
+| [Ideone](https://ideone.com/) | 1 | C++14 | 1.62 (header only) | ✔️ | GCC | ✔️ |
+| [Visual C++ Compiler Online](http://webcompiler.cloudapp.net/) | 1 | C++14-17 |  | ✔️ | up-to-date MSVC 19/2017 |  |
+| [C++ Shell](http://cpp.sh/) | 1 | C++11-14 | 1.55 (header only) | ✔️ | GCC, interactive Stdin |  |
+| [repl.it](https://repl.it/languages/cpp11) | 1 | C++17 |  | ✔️ | GCC, interactive Stdin | ✔️ |
+| [Tutorialspoint CodingGround](https://www.tutorialspoint.com/compile_cpp11_online.php) | 1 | C++11 |  | ✔️ | multiple files like proper IDE, GCC <br/> but sluggish web app |  |
+| [Codepad](http://codepad.org/) | 1 | C++03 | 1.34 | ✔️ | GCC | ✔️ |
+| [TIO - Try It Online](https://tio.run/#cpp-gcc) | 1 | C++14 |  | ✔️ | Easy sharing, split source in header, source and footer | ✔️ |
+| [LoopPerfect C++ Fiddle](http://fiddle.jyt.io/) |  | | | | interactive C++ interpreter/terminal, but currently broken |  |
 
 ## The Compilers 
 


### PR DESCRIPTION
Add column "boost version" to the table. Add corresponding badges to compilers. Remove boost badge from Compiler Explorer (Godbolt), it does not support boost (or do I miss something?).