### PR TITLE
Include Codiva.io in the list of compilers

### DIFF
--- a/index.md
+++ b/index.md
@@ -35,7 +35,7 @@ Besides mere compilation, most online compilers also execute the compiled progra
 
 ### [Codiva.io](https://www.codiva.io)
 ![C++14](https://img.shields.io/badge/C++-14-blue.svg)
-![Clang 3.5](https://img.shields.io/badge/Clang-4.0-008080.svg)
+![Clang 3.5](https://img.shields.io/badge/Clang-3.5-008080.svg)
 ![Compiler flags: predefined](https://img.shields.io/badge/flags-predefined-brightgreen.svg)
 ![Runtime parameters: no](https://img.shields.io/badge/runtime%20parameters-no-brightgreen.svg)
 ![Stdin: yes](https://img.shields.io/badge/stdin-yes-brightgreen.svg)  

--- a/index.md
+++ b/index.md
@@ -14,6 +14,7 @@ Besides mere compilation, most online compilers also execute the compiled progra
 
 | Name | Number Compilers | C++ Version | Boost Version | Execution | Distinguishing Features | Other Languages |
 |------|:----------------:|:-----------:|:-------------:|:---------:|-------------------------|:---------------:|
+| [Codiva.io](https://www.codiva.io/) | 1 | C++14 |  | ✔️ | Clang, user input, multiple files, continuous compilation every few keystrokes, sharing and embeding in blogs | ✔️ |
 | [paiza.IO](https://paiza.IO/) | 1 | C++14 |  | ✔️ | multiple files, collaborative live editing, full screen editor, Internet connection, GitHub(gist) integration | ✔️ |
 | [Wandbox](http://melpon.org/wandbox) | 35 | C++17 | 1.64 | ✔️ | multiple files | ✔️ |
 | [Compiler Explorer (Godbolt)](http://godbolt.org) | 60+ | C++17 | 1.64 |  | compile to assembly as you type, on multiple compilers | ✔️ |
@@ -31,6 +32,18 @@ Besides mere compilation, most online compilers also execute the compiled progra
 | [LoopPerfect C++ Fiddle](http://fiddle.jyt.io/) |  | | | | interactive C++ interpreter/terminal, but currently broken |  |
 
 ## The Compilers 
+
+### [Codiva.io](https://www.codiva.io)
+![C++14](https://img.shields.io/badge/C++-14-blue.svg)
+![Clang 3.5](https://img.shields.io/badge/Clang-4.0-008080.svg)
+![Compiler flags: predefined](https://img.shields.io/badge/flags-predefined-brightgreen.svg)
+![Runtime parameters: no](https://img.shields.io/badge/runtime%20parameters-no-brightgreen.svg)
+![Stdin: yes](https://img.shields.io/badge/stdin-yes-brightgreen.svg)  
+![](https://img.shields.io/badge/multi%20file-yes-ff69b4.svg)
+![](https://img.shields.io/badge/sharing-link-ff69b4.svg)
+![](https://img.shields.io/badge/sharing-link%20|%20embed-ff69b4.svg)
+
+[Codiva.io](https://www.codiva.io) is an online compiler and IDE that allows to edit, compile, execute and share multiple C++ files. As a distinguishing feature, it compiles the code every few keystrokes, and highlights the error lines in the editor itself saving time. It even works on mobile.
 
 ### [paiza.IO](https://paiza.IO)
 ![C++14](https://img.shields.io/badge/C++-14-blue.svg)


### PR DESCRIPTION
Codiva online compiler and IDE supports C, C++ and Java. 

It has syntax highlighting, continuous compilation, and works on mobile.